### PR TITLE
Updates urllib3 requirement to patch CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ certifi==2018.11.29
 chardet==3.0.4
 idna==2.7
 requests==2.20.1
-urllib3==1.24.1
+urllib3==1.24.2


### PR DESCRIPTION
With the upgrade, we simply patch the CVE-2019-11324 of the urllib3 package